### PR TITLE
Fix bugs in null-model extractor

### DIFF
--- a/extractor/src/main/java/npex/extractor/nullhandle/AbstractNullHandle.java
+++ b/extractor/src/main/java/npex/extractor/nullhandle/AbstractNullHandle.java
@@ -35,6 +35,7 @@ import spoon.reflect.code.CtExpression;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.factory.CoreFactory;
 import spoon.support.DefaultCoreFactory;
+import npex.common.NPEXException;
 
 public abstract class AbstractNullHandle<T extends CtElement> {
   static final protected Logger logger = LoggerFactory.getLogger(AbstractNullHandle.class);
@@ -55,7 +56,7 @@ public abstract class AbstractNullHandle<T extends CtElement> {
     this.models = scanner.getResult();
   }
 
-  public JSONObject toJSON() {
+  public JSONObject toJSON() throws NPEXException {
     var obj = new JSONObject();
     obj.put("source_path", handle.getPosition().getFile().getAbsolutePath());
     obj.put("lineno", handle.getPosition().getLine());

--- a/extractor/src/main/java/npex/extractor/nullhandle/AbstractNullModelScanner.java
+++ b/extractor/src/main/java/npex/extractor/nullhandle/AbstractNullModelScanner.java
@@ -51,6 +51,9 @@ public abstract class AbstractNullModelScanner extends EarlyTerminatingScanner<L
     }
   }
 
-  protected abstract NullModel createModel(CtInvocation invo);
+  protected boolean isTargetInvocation(CtInvocation invo) {
+    return invo.getTarget().equals(nullExp) || invo.getArguments().contains(nullExp);
+  }
 
+  protected abstract NullModel createModel(CtInvocation invo);
 }

--- a/extractor/src/main/java/npex/extractor/nullhandle/BooleanNullHandle.java
+++ b/extractor/src/main/java/npex/extractor/nullhandle/BooleanNullHandle.java
@@ -57,12 +57,14 @@ public class BooleanNullHandle extends AbstractNullHandle<CtBinaryOperator<Boole
         if (!kind.equals(handleBoKind)) {
           terminate();
         }
-      }
-      root = bo.getRightHandOperand();
-      if (root instanceof CtBinaryOperator boRHS) {
-        visitCtBinaryOperator(boRHS);
-      } else if (root instanceof CtInvocation invo) {
-        super.visitCtInvocation(invo);
+        root = bo.getRightHandOperand();
+        if (root instanceof CtBinaryOperator boRHS) {
+          visitCtBinaryOperator(boRHS);
+        } else if (root instanceof CtInvocation invo) {
+          super.visitCtInvocation(invo);
+        } else {
+          terminate();
+        }
       } else {
         terminate();
       }

--- a/extractor/src/main/java/npex/extractor/nullhandle/BooleanNullHandle.java
+++ b/extractor/src/main/java/npex/extractor/nullhandle/BooleanNullHandle.java
@@ -60,8 +60,9 @@ public class BooleanNullHandle extends AbstractNullHandle<CtBinaryOperator<Boole
         root = bo.getRightHandOperand();
         if (root instanceof CtBinaryOperator boRHS) {
           visitCtBinaryOperator(boRHS);
-        } else if (root instanceof CtInvocation invo) {
-          super.visitCtInvocation(invo);
+        } else if (root instanceof CtInvocation invo && isTargetInvocation(invo)) {
+          models.add(createModel(invo));
+          terminate();
         } else {
           terminate();
         }

--- a/extractor/src/main/java/npex/extractor/nullhandle/NullModel.java
+++ b/extractor/src/main/java/npex/extractor/nullhandle/NullModel.java
@@ -66,7 +66,7 @@ public class NullModel {
   public JSONObject toJSON() {
     var obj = new JSONObject();
     obj.put("sink_body", sinkBody.toString());
-    obj.put("null_value", nullValue != null ? abstractNullValue(nullValue) : JSONObject.NULL);
+    obj.put("null_value", abstractNullValue(nullValue));
     obj.put("actual_null_value", nullValue != null ? nullValue.toString() : JSONObject.NULL);
     obj.put("invocation_info", invoInfo != null ? invoInfo.toJSON() : JSONObject.NULL);
     obj.put("invocation_key", invoKey != null ? invoKey.toJSON() : JSONObject.NULL);

--- a/extractor/src/main/java/npex/extractor/nullhandle/NullModel.java
+++ b/extractor/src/main/java/npex/extractor/nullhandle/NullModel.java
@@ -32,6 +32,7 @@ import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import npex.common.NPEXException;
 import npex.common.utils.FactoryUtils;
 import npex.extractor.context.ContextExtractor;
 import npex.extractor.invocation.InvocationKey;
@@ -39,6 +40,7 @@ import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtInvocation;
 import spoon.reflect.code.CtLiteral;
 import spoon.reflect.declaration.CtElement;
+import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.EarlyTerminatingScanner;
 
 public class NullModel {
@@ -63,7 +65,7 @@ public class NullModel {
     this.contexts = invoInfo != null ? ContextExtractor.extract(invoInfo.orgInvo(), invoInfo.nullIdx()) : null;
   }
 
-  public JSONObject toJSON() {
+  public JSONObject toJSON() throws NPEXException {
     var obj = new JSONObject();
     obj.put("sink_body", sinkBody.toString());
     obj.put("null_value", abstractNullValue(nullValue));
@@ -74,7 +76,17 @@ public class NullModel {
     return obj;
   }
 
-  private String abstractNullValue(CtExpression nullValue) {
+  private String abstractNullValue(CtExpression nullValue) throws NPEXException {
+    if (invoInfo == null || nullValue == null) {
+      throw new NPEXException(
+          String.format("Cannot extract null values for model {}: invoaction infomation is incomplete!", this));
+    }
+    CtTypeReference valueType = nullValue.getType();
+    CtTypeReference invoRetType = invoInfo.orgInvo().getType();
+    if (valueType != null && !valueType.isSubtypeOf(invoRetType)) {
+      throw new NPEXException(String.format("Cannot extract null values for model {}: {} is not a subtype of {}", this,
+          valueType, invoRetType));
+    }
     if (nullValue instanceof CtLiteral) {
       return nullValue.toString();
     } else {

--- a/extractor/src/main/java/npex/extractor/processors/NullHandleProcessor.java
+++ b/extractor/src/main/java/npex/extractor/processors/NullHandleProcessor.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.json.JSONArray;
+import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,6 +39,7 @@ import npex.extractor.nullhandle.AbstractNullHandle;
 import npex.extractor.nullhandle.NullHandleFactory;
 import spoon.processing.AbstractProcessor;
 import spoon.reflect.code.CtCodeElement;
+import npex.common.NPEXException;
 
 public class NullHandleProcessor extends AbstractProcessor<CtCodeElement> {
   static Logger logger = LoggerFactory.getLogger(NullHandleProcessor.class);
@@ -66,7 +68,15 @@ public class NullHandleProcessor extends AbstractProcessor<CtCodeElement> {
 
   @Override
   public void processingDone() {
-    JSONArray handlesJsonArray = new JSONArray(handles.stream().map(h -> h.toJSON()).toArray());
+    List<JSONObject> jsons = new ArrayList<>();
+    for (var h : handles) {
+      try {
+        jsons.add(h.toJSON());
+      } catch (NPEXException e) {
+        logger.info(e.getMessage());
+      }
+    }
+    JSONArray handlesJsonArray = new JSONArray(jsons);
     try (BufferedWriter writer = new BufferedWriter(new FileWriter(resultsOut))) {
       handlesJsonArray.write(writer, 1, 4);
     } catch (IOException e) {


### PR DESCRIPTION
- Do not collect models for intermediate invocations: e.g., model of `goo` in `if (p != null) p.foo().goo()`.
- Collect null-value only if its type matches with the return type (subtype).