### PR TITLE
Add non-void skip contexts

### DIFF
--- a/extractor/src/main/java/npex/extractor/context/AbstractCalleeMethodContext.java
+++ b/extractor/src/main/java/npex/extractor/context/AbstractCalleeMethodContext.java
@@ -1,0 +1,19 @@
+package npex.extractor.context;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import spoon.reflect.code.CtInvocation;
+import spoon.reflect.declaration.CtExecutable;
+
+public abstract class AbstractCalleeMethodContext implements Context {
+  final static Logger logger = LoggerFactory.getLogger(AbstractCalleeMethodContext.class);
+
+  public Boolean extract(CtInvocation invo, int nullpos) {
+    CtExecutable exec = invo.getExecutable().getExecutableDeclaration();
+    return exec != null ? predicateOnMethod(exec) : false;
+  }
+
+  protected abstract boolean predicateOnMethod(CtExecutable exec);
+
+}

--- a/extractor/src/main/java/npex/extractor/context/AbstractCallerMethodContext.java
+++ b/extractor/src/main/java/npex/extractor/context/AbstractCallerMethodContext.java
@@ -15,6 +15,6 @@ public abstract class AbstractCallerMethodContext implements Context {
     return exec != null && predicateOnMethod(exec);
   }
 
-  protected abstract boolean predicateOnMethod(CtExecutable exec);
+  protected abstract boolean predicateOnMethod(CtExecutable callee);
 
 }

--- a/extractor/src/main/java/npex/extractor/context/AbstractCallerMethodContext.java
+++ b/extractor/src/main/java/npex/extractor/context/AbstractCallerMethodContext.java
@@ -7,7 +7,7 @@ import npex.common.filters.MethodOrConstructorFilter;
 import spoon.reflect.code.CtInvocation;
 import spoon.reflect.declaration.CtExecutable;
 
-public abstract class AbstractSinkMethodContext implements Context {
+public abstract class AbstractCallerMethodContext implements Context {
   final static Logger logger = LoggerFactory.getLogger(AbstractVariableTypeContext.class);
 
   public Boolean extract(CtInvocation invo, int nullPos) {

--- a/extractor/src/main/java/npex/extractor/context/CalleeMethodReturnsVoid.java
+++ b/extractor/src/main/java/npex/extractor/context/CalleeMethodReturnsVoid.java
@@ -1,0 +1,10 @@
+package npex.extractor.context;
+
+import spoon.reflect.declaration.CtExecutable;
+
+public class CalleeMethodReturnsVoid extends AbstractCalleeMethodContext {
+  protected boolean predicateOnMethod(CtExecutable callee) {
+    return callee.getType().equals("void");
+  }
+
+}

--- a/extractor/src/main/java/npex/extractor/context/CallerMethodIsConstructor.java
+++ b/extractor/src/main/java/npex/extractor/context/CallerMethodIsConstructor.java
@@ -3,7 +3,7 @@ package npex.extractor.context;
 import spoon.reflect.declaration.CtConstructor;
 import spoon.reflect.declaration.CtExecutable;
 
-public class SinkMethodIsConstructor extends AbstractSinkMethodContext {
+public class CallerMethodIsConstructor extends AbstractCallerMethodContext {
   protected boolean predicateOnMethod(CtExecutable exec) {
     return exec instanceof CtConstructor;
   }

--- a/extractor/src/main/java/npex/extractor/context/CallerMethodIsPrivate.java
+++ b/extractor/src/main/java/npex/extractor/context/CallerMethodIsPrivate.java
@@ -3,7 +3,7 @@ package npex.extractor.context;
 import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.declaration.CtMethod;
 
-public class SinkMethodIsPrivate extends AbstractSinkMethodContext {
+public class CallerMethodIsPrivate extends AbstractCallerMethodContext {
   protected boolean predicateOnMethod(CtExecutable exec) {
     return exec instanceof CtMethod mthd && mthd.isPrivate();
   }

--- a/extractor/src/main/java/npex/extractor/context/CallerMethodIsPublic.java
+++ b/extractor/src/main/java/npex/extractor/context/CallerMethodIsPublic.java
@@ -3,8 +3,8 @@ package npex.extractor.context;
 import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.declaration.CtMethod;
 
-public class SinkMethodIsStatic extends AbstractSinkMethodContext {
+public class CallerMethodIsPublic extends AbstractCallerMethodContext {
   protected boolean predicateOnMethod(CtExecutable exec) {
-    return exec instanceof CtMethod mthd && mthd.isStatic();
+    return exec instanceof CtMethod mthd && mthd.isPublic();
   }
 }

--- a/extractor/src/main/java/npex/extractor/context/CallerMethodIsStatic.java
+++ b/extractor/src/main/java/npex/extractor/context/CallerMethodIsStatic.java
@@ -3,8 +3,8 @@ package npex.extractor.context;
 import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.declaration.CtMethod;
 
-public class SinkMethodIsPublic extends AbstractSinkMethodContext {
+public class CallerMethodIsStatic extends AbstractCallerMethodContext {
   protected boolean predicateOnMethod(CtExecutable exec) {
-    return exec instanceof CtMethod mthd && mthd.isPublic();
+    return exec instanceof CtMethod mthd && mthd.isStatic();
   }
 }

--- a/extractor/src/main/java/npex/extractor/context/ContextFactory.java
+++ b/extractor/src/main/java/npex/extractor/context/ContextFactory.java
@@ -41,10 +41,10 @@ public class ContextFactory {
     contexts.add(new IsField());
     contexts.add(new SinkExprIsAssigned());
     contexts.add(new SinkExprIsExceptionArgument());
-    contexts.add(new SinkMethodIsConstructor());
-    contexts.add(new SinkMethodIsPrivate());
-    contexts.add(new SinkMethodIsPublic());
-    contexts.add(new SinkMethodIsStatic());
+    contexts.add(new CallerMethodIsConstructor());
+    contexts.add(new CallerMethodIsPrivate());
+    contexts.add(new CallerMethodIsPublic());
+    contexts.add(new CallerMethodIsStatic());
     contexts.add(new VariableIsObjectType());
     contexts.add(new VariableIsFinal());
   }

--- a/extractor/src/main/java/npex/extractor/context/ContextFactory.java
+++ b/extractor/src/main/java/npex/extractor/context/ContextFactory.java
@@ -47,6 +47,8 @@ public class ContextFactory {
     contexts.add(new CallerMethodIsStatic());
     contexts.add(new VariableIsObjectType());
     contexts.add(new VariableIsFinal());
+    contexts.add(new InvocationIsIsolated());
+    contexts.add(new CalleeMethodReturnsVoid());
   }
 
   public static List<Context> getAllContexts() {

--- a/extractor/src/main/java/npex/extractor/context/InvocationIsIsolated.java
+++ b/extractor/src/main/java/npex/extractor/context/InvocationIsIsolated.java
@@ -1,0 +1,10 @@
+package npex.extractor.context;
+
+import npex.common.utils.ASTUtils;
+import spoon.reflect.code.CtInvocation;
+
+public class InvocationIsIsolated implements Context {
+  public Boolean extract(CtInvocation invo, int nullPos) {
+    return ASTUtils.getEnclosingStatement(invo).equals(invo);
+  }
+}

--- a/scripts/data.py
+++ b/scripts/data.py
@@ -7,6 +7,8 @@ import pickle
 import json
 from re import finditer
 
+from dacite.exceptions import MissingValueError
+
 
 def camel_case_split(identifier):
     matches = finditer('.+?(?:(?<=[a-z])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])|$)',
@@ -83,6 +85,8 @@ class Contexts(JSONData):
     CallerMethodIsStatic: bool
     VariableIsObjectType: bool
     VariableIsFinal: bool
+    InvocationIsIsolated: bool
+    CalleeMethodReturnsVoid: bool
 
     def to_boolean_vector(self):
         return [1 if b else 0 for b in self.__dict__.values()]
@@ -112,7 +116,12 @@ class DB:
         handles = []
         for h in JSONData.read_json_from_file(handles_json):
             for m in h['models']:
-                model = NullModel.from_dict(m)
+                try:
+                    model = NullModel.from_dict(m)
+                except MissingValueError: 
+                    print(m)
+                    continue
+
                 handle = NullHandle(h['source_path'], h['lineno'], h['handle'],
                                     model)
                 handles.append(handle)

--- a/scripts/data.py
+++ b/scripts/data.py
@@ -77,10 +77,10 @@ class Contexts(JSONData):
     LHSIsPublic: bool
     SinkExprIsAssigned: bool
     SinkExprIsExceptionArgument: bool
-    SinkMethodIsConstructor: bool
-    SinkMethodIsPrivate: bool
-    SinkMethodIsPublic: bool
-    SinkMethodIsStatic: bool
+    CallerMethodIsConstructor: bool
+    CallerMethodIsPrivate: bool
+    CallerMethodIsPublic: bool
+    CallerMethodIsStatic: bool
     VariableIsObjectType: bool
     VariableIsFinal: bool
 


### PR DESCRIPTION
- Rename contexts: Sink.* -> Caller.*
- Add contexts to describe non-void but skipped invocations: e.g. `if (p != null) p.remove()`, where `remove` returns boolean